### PR TITLE
Fixes for upstream

### DIFF
--- a/update_repos
+++ b/update_repos
@@ -7,6 +7,7 @@ import argparse
 from collections import namedtuple
 from subprocess import Popen, PIPE
 
+from urllib import urlencode
 from urllib2 import urlopen
 import json
 from urlparse import urlparse
@@ -15,8 +16,9 @@ WHITELIST=[]
 BLACKLIST=[]
 
 LISTINGS_PER_PAGE = 100
-ACCESS_TOKEN_PARAM = '?access_token=%s'
-LISTING_PAGE_PARAM = '&per_page=%d&page=%d'
+ACCESS_TOKEN_PARAM = 'access_token'
+LISTINGS_PER_PAGE_PARAM = 'per_page'
+LISTING_PAGE_PARAM = 'page'
 GITHUB_API_HOST = 'https://api.github.com'
 
 GIT_CLONE_CMD = 'git clone %s %s %s'
@@ -73,7 +75,12 @@ class AttributeDict(dict):
         self[attr] = value
 
 def read_api_uri(uri, config, page=1):
-    uri += ACCESS_TOKEN_PARAM % config.token + LISTING_PAGE_PARAM % (LISTINGS_PER_PAGE, page)
+    params = {
+        ACCESS_TOKEN_PARAM: config.token,
+        LISTINGS_PER_PAGE_PARAM: LISTINGS_PER_PAGE,
+        LISTING_PAGE_PARAM: page,
+    }
+    uri += '?' + urlencode(params)
 
     if config.debug:
         print "Trying:", uri

--- a/update_repos
+++ b/update_repos
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # encoding: utf-8
 
+import base64
 import sys
 import os
 import argparse
@@ -8,7 +9,7 @@ from collections import namedtuple
 from subprocess import Popen, PIPE
 
 from urllib import urlencode
-from urllib2 import urlopen
+from urllib2 import Request, urlopen
 import json
 from urlparse import urlparse
 
@@ -16,7 +17,6 @@ WHITELIST=[]
 BLACKLIST=[]
 
 LISTINGS_PER_PAGE = 100
-ACCESS_TOKEN_PARAM = 'access_token'
 LISTINGS_PER_PAGE_PARAM = 'per_page'
 LISTING_PAGE_PARAM = 'page'
 GITHUB_API_HOST = 'https://api.github.com'
@@ -76,16 +76,22 @@ class AttributeDict(dict):
 
 def read_api_uri(uri, config, page=1):
     params = {
-        ACCESS_TOKEN_PARAM: config.token,
         LISTINGS_PER_PAGE_PARAM: LISTINGS_PER_PAGE,
         LISTING_PAGE_PARAM: page,
     }
     uri += '?' + urlencode(params)
 
-    if config.debug:
-        print "Trying:", uri
+    creds = base64.b64encode(config.token.encode('utf-8')).decode('ascii')
+    basic_auth = 'Basic {}'.format(creds)
+    headers = {
+        'Authorization': basic_auth,
+    }
 
-    return urlopen(uri).read()
+    if config.debug:
+        print "Trying URI {} with headers {}".format(uri, headers)
+
+    req = Request(uri, headers=headers)
+    return urlopen(req).read()
 
 def get_json(uri, config, obj_type=AttributeDict, page=1):
     return json.loads(read_api_uri(uri, config, page), object_hook=obj_type)

--- a/update_repos
+++ b/update_repos
@@ -22,7 +22,7 @@ GITHUB_API_HOST = 'https://api.github.com'
 GIT_CLONE_CMD = 'git clone %s %s %s'
 GIT_CLONE_API_URL = 'https://%s@github.com/%s'
 GIT_SHA_CMD = 'git rev-parse --short %s'
-GIT_FETCH_CMD = 'git fetch'
+GIT_FETCH_CMD = 'git fetch --tags'
 GIT_CHECK_REMOTE_CMD = 'git ls-remote'
 
 USER_DETAILS_PATH = '/users/%s'


### PR DESCRIPTION
A couple fixes we've accumulated at Endless. The last one stops using GitHub's deprecated `access_token` query parameter when accessing the API.